### PR TITLE
Introduce Phoenix.LiveController.ViewRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.4.0-dev
+
+### Enhancements
+
+- Introduce `Phoenix.LiveController.ViewRenderer` that renders live view or component with a view &
+  template named after the live module & live action, allowing to consistently hold all templates in
+  `lib/my_app_web/templates` directory and to consistently back them with view modules in order to
+  accommodate the view logic - even when using live controllers together with regular live views and
+  live components
+
+### Backwards incompatible changes
+
+- Call to `use Phoenix.LiveController` no longer provides the rendering behaviour that was moved to
+  ViewRenderer so a separate `use Phoenix.LiveController.ViewRenderer` call is needed
+
 ## 0.3.0 (2020-04-21)
 
 This release pushes LiveController from being a simple action & event router into a more complete

--- a/lib/phoenix_live_controller.ex
+++ b/lib/phoenix_live_controller.ex
@@ -398,16 +398,7 @@ defmodule Phoenix.LiveController do
 
   ## Rendering actions
 
-  Implementation of the `c:Phoenix.LiveView.render/1` callback may be omitted in which case the
-  default implementation will be injected. It'll ask the view module named after specific live
-  module to render HTML template named after the action - the same way that Phoenix controllers do
-  when the `Phoenix.Controller.render/2` is called without a template name.
-
-  For example, `MyAppWeb.ArticleLive` mounted with `:index` action will render with following call:
-
-      MyAppWeb.ArticleView.render("index.html", assigns)
-
-  Custom `c:Phoenix.LiveView.render/1` implementation may still be provided if necessary.
+  See `Phoenix.LiveController.ViewRenderer`.
 
   """
 
@@ -530,13 +521,6 @@ defmodule Phoenix.LiveController do
                       message_handler: 3
 
   defmacro __using__(opts) do
-    view_module =
-      __CALLER__.module
-      |> to_string()
-      |> String.replace(~r/(Live|LiveController)$/, "")
-      |> Kernel.<>("View")
-      |> String.to_atom()
-
     quote do
       use Phoenix.LiveView, unquote(opts)
 
@@ -561,9 +545,6 @@ defmodule Phoenix.LiveController do
 
       def handle_event(event_string, params, socket),
         do: unquote(__MODULE__)._handle_event(__MODULE__, event_string, params, socket)
-
-      def render(assigns = %{live_action: action}),
-        do: unquote(view_module).render("#{action}.html", assigns)
 
       # Default implementations of Phoenix.LiveController callbacks
 
@@ -594,8 +575,7 @@ defmodule Phoenix.LiveController do
                      message_handler: 3,
                      before_action_handler: 3,
                      before_event_handler: 3,
-                     before_message_handler: 3,
-                     render: 1
+                     before_message_handler: 3
     end
   end
 

--- a/lib/phoenix_live_controller/view_renderer.ex
+++ b/lib/phoenix_live_controller/view_renderer.ex
@@ -1,0 +1,104 @@
+defmodule Phoenix.LiveController.ViewRenderer do
+  @moduledoc ~S"""
+  Renders live view or component with a view & template named after the live module & action.
+
+  Implementation of the `c:Phoenix.LiveView.render/1` callback may be omitted in which case [a
+  collocated template is used as a
+  default](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.html#module-collocating-templates).
+  This basically means that `Phoenix.LiveView` seeks for the template with the same filename as live
+  module, with `.ex` extension replaced by `.html.leex`.
+
+  ViewRenderer allows to opt-in for a more controller-style behaviour in which views are invoked to
+  render templates from the `lib/my_app_web/templates` directory.
+
+      defmodule MyAppWeb do
+        def live_component do
+          quote do
+            use Phoenix.LiveComponent
+            use Phoenix.LiveController.ViewRenderer
+            # ...
+          end
+        end
+
+        def live_controller do
+          quote do
+            use Phoenix.LiveController
+            use Phoenix.LiveController.ViewRenderer
+            # ...
+          end
+        end
+
+        def live_view do
+          quote do
+            use Phoenix.LiveView
+            use Phoenix.LiveController.ViewRenderer
+            # ...
+          end
+        end
+      end
+
+  This will inject an implementation of `c:Phoenix.LiveView.render/1` callback that'll ask the view
+  module named after specific live module to render HTML template named after the action - the same
+  way that Phoenix controllers do when the `Phoenix.Controller.render/2` is called without a
+  template name. For example, `MyAppWeb.ArticleLive` mounted with `:index` action will render with
+  following call:
+
+      MyAppWeb.ArticleView.render("index.html", assigns)
+
+  Furthermore, for live sub-views or sub-components it'll assume that they're backed by a single
+  template and so the injected implementation will ask the view module named after parent live
+  module to render HTML template named after the sub-module. For example,
+  `MyAppWeb.ArticleLive.FormComponent` will render with following call:
+
+      MyAppWeb.ArticleView.render("form.html", assigns)
+
+  This, together with ViewRenderer being separate from LiveController, allows to consistently hold
+  all templates in `lib/my_app_web/templates` directory and to consistently back them with view
+  modules in order to accommodate the view logic - even when using live controllers together with
+  regular live views and live components.
+
+  Provided renderer is overridable, which means that a custom `c:Phoenix.LiveView.render/1`
+  implementation may still be provided if necessary.
+
+  """
+
+  defmacro __using__(_opts) do
+    caller_module_string = to_string(__CALLER__.module)
+
+    case Regex.run(~r/(.*Live)\.(\w+)$/, caller_module_string) do
+      [_, parent_module_string, submodule] ->
+        view_module = live_module_string_to_view_module(parent_module_string)
+
+        action =
+          submodule
+          |> String.replace(~r/(Live|Component)$/, "")
+          |> Macro.underscore()
+
+        quote do
+          def render(assigns) do
+            unquote(view_module).render("#{unquote(action)}.html", assigns)
+          end
+
+          defoverridable render: 1
+        end
+
+      _ ->
+        view_module = live_module_string_to_view_module(caller_module_string)
+
+        quote do
+          def render(assigns = %{live_action: action}) do
+            unquote(view_module).render("#{action}.html", assigns)
+          end
+
+          defoverridable render: 1
+        end
+    end
+  end
+
+  defp live_module_string_to_view_module(live_module_string) do
+    live_module_string
+    |> String.replace(~r/Live$/, "")
+    |> Kernel.<>("View")
+    |> String.to_atom()
+  end
+end

--- a/test/phoenix_live_controller_test.exs
+++ b/test/phoenix_live_controller_test.exs
@@ -275,4 +275,13 @@ defmodule Phoenix.LiveControllerTest do
     assert {:rendered, "index.html", %{live_action: :index, other: :x}} =
              SampleLive.render(socket.assigns)
   end
+
+  test "rendering live submodules" do
+    socket =
+      %Phoenix.LiveView.Socket{}
+      |> assign(other: :x)
+
+    assert {:rendered, "some.html", %{other: :x}} =
+             SampleLive.SomeComponent.render(socket.assigns)
+  end
 end

--- a/test/support/sample_live.ex
+++ b/test/support/sample_live.ex
@@ -1,5 +1,6 @@
 defmodule SampleLive do
   use Phoenix.LiveController
+  use Phoenix.LiveController.ViewRenderer
 
   @impl true
   def apply_session(socket, session) do

--- a/test/support/sample_live/some_component.ex
+++ b/test/support/sample_live/some_component.ex
@@ -1,0 +1,4 @@
+defmodule SampleLive.SomeComponent do
+  use Phoenix.LiveComponent
+  use Phoenix.LiveController.ViewRenderer
+end


### PR DESCRIPTION
Introduce `Phoenix.LiveController.ViewRenderer` that renders live view or component with a view & template named after the live module & live action, allowing to consistently hold all templates in `lib/my_app_web/templates` directory and to consistently back them with view modules in order to accommodate the view logic - even when using live controllers together with regular live views and live components.

Breaking change: Call to `use Phoenix.LiveController` no longer provides the rendering behaviour that was moved to ViewRenderer so a separate `use Phoenix.LiveController.ViewRenderer` call is needed.